### PR TITLE
Remove deprecation warning in rails 7

### DIFF
--- a/lib/rspec/apidoc.rb
+++ b/lib/rspec/apidoc.rb
@@ -119,7 +119,7 @@ module RSpec
         action_name: action_name,
         action_comment: action_comment,
 
-        content_type: spec.request.content_type,
+        content_type: spec.request.media_type,
         auth_header: auth_header(spec.request.headers),
         method: spec.request.method,
         path: spec.request.path,
@@ -127,7 +127,7 @@ module RSpec
         request_body: request_body,
 
         status: spec.response.status,
-        response_content_type: spec.response.content_type,
+        response_content_type: spec.response.media_type,
         response_body: response_body
       }
     end


### PR DESCRIPTION
Rails 7 gives the following deprecation warning when running rspec-apidoc:
```
Rails 7.1 will return Content-Type header without modification. If you want just the MIME type, please use `#media_type` instead.
```

This PR updates to the new `#media_type` method which has the same behavior as older versions of `content_type` 